### PR TITLE
Add 'Delete Old Records' feature to expense and income

### DIFF
--- a/budgetcreating.ui
+++ b/budgetcreating.ui
@@ -22,7 +22,7 @@
   </property>
   <property name="styleSheet">
    <string notr="true">
-QDialog{border-image: url(:/image/Background04.png) 0 0 0 0 stretch stretch;}
+#Budgetcreating{border-image: url(:/image/Background04.png) 0 0 0 0 stretch stretch;}
 </string>
   </property>
   <widget class="QPushButton" name="pushButton_back">

--- a/expense.cpp
+++ b/expense.cpp
@@ -195,3 +195,32 @@ void Expense::checkAllCategoryBudgets()
         }
     }
 }
+
+void Expense::on_deleteOldRecordsButton_clicked()
+{
+    // 1. Ask the user to confirm this dangerous action.
+    bool confirmed = AppUtils::askQuestion(this, "Confirm Deletion",
+                                           "Are you sure you want to permanently delete all expense records from previous months?\n\nThis action cannot be undone.");
+
+    // 2. If the user clicks "No", stop right here.
+    if (!confirmed) {
+        return;
+    }
+
+    // 3. Prepare the SQL query to delete records for the current user
+    //    where the date is less than the first day of the current month.
+    QSqlQuery query(DatabaseManager::instance().getDatabase());
+    query.prepare("DELETE FROM expensedata WHERE username = :username AND date < date('now', 'start of month')");
+    query.bindValue(":username", globalUsername);
+
+    // 4. Execute the query and show a success or failure message.
+    if (query.exec()) {
+        AppUtils::showMessage(this, "Success", "Old expense records have been deleted.");
+    } else {
+        qWarning() << "Failed to delete old expense records:" << query.lastError().text();
+        AppUtils::showMessage(this, "Database Error", "Could not delete old records.");
+    }
+
+    // 5. Refresh the table view to show that the old records are gone.
+    refreshTable();
+}

--- a/expense.h
+++ b/expense.h
@@ -37,6 +37,7 @@ private slots:
     void on_pushButton_backto_clicked();
 
     void on_pushButton_add_clicked();
+    void on_deleteOldRecordsButton_clicked();
 
 private:
     void checkAllCategoryBudgets(); // Checks all budgets when the window opens.

--- a/expense.ui
+++ b/expense.ui
@@ -173,16 +173,13 @@ color: white;</string>
        </property>
        <property name="dateTime">
         <datetime>
-         <hour>5</hour>
-         <minute>30</minute>
+         <hour>0</hour>
+         <minute>0</minute>
          <second>0</second>
          <year>2000</year>
          <month>2</month>
          <day>1</day>
         </datetime>
-       </property>
-       <property name="timeSpec">
-        <enum>Qt::TimeSpec::LocalTime</enum>
        </property>
       </widget>
      </item>
@@ -317,6 +314,28 @@ color: white;</string>
    </property>
    <property name="text">
     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:36pt; font-weight:700; color:#841ebc;&quot;&gt;EXPENSE TRACKER&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+   </property>
+  </widget>
+  <widget class="QPushButton" name="deleteOldRecordsButton">
+   <property name="geometry">
+    <rect>
+     <x>1030</x>
+     <y>720</y>
+     <width>141</width>
+     <height>31</height>
+    </rect>
+   </property>
+   <property name="styleSheet">
+    <string notr="true">border: 3px solid #ff000d;
+background-color:#ff000d;
+border-radius: 15px;
+color: white;
+font: 700 10pt &quot;Segoe UI&quot;;
+
+</string>
+   </property>
+   <property name="text">
+    <string>Delete Old Records</string>
    </property>
   </widget>
  </widget>

--- a/financialreports.ui
+++ b/financialreports.ui
@@ -18,7 +18,7 @@
     <normaloff>:/image/window_icon.png</normaloff>:/image/window_icon.png</iconset>
   </property>
   <property name="styleSheet">
-   <string notr="true">QDialog{border-image: url(:/image/Background04.png) 0 0 0 0 stretch stretch;}
+   <string notr="true">#financialreports{border-image: url(:/image/Background04.png) 0 0 0 0 stretch stretch;}
 </string>
   </property>
   <widget class="QGroupBox" name="groupBox">

--- a/incomeui.cpp
+++ b/incomeui.cpp
@@ -101,3 +101,31 @@ void Incomeui::on_pushButton_Add_clicked()
 
 }
 
+void Incomeui::on_deleteOldRecordsButton_clicked()
+{
+    // 1. Ask the user to confirm this dangerous action.
+    bool confirmed = AppUtils::askQuestion(this, "Confirm Deletion",
+                                           "Are you sure you want to permanently delete all income records from previous months?\n\nThis action cannot be undone.");
+
+    // 2. If the user clicks "No", stop right here.
+    if (!confirmed) {
+        return;
+    }
+
+    // 3. Prepare the SQL query to delete records for the current user
+    //    where the date is less than the first day of the current month.
+    QSqlQuery query(DatabaseManager::instance().getDatabase());
+    query.prepare("DELETE FROM incomedata WHERE username = :username AND date < date('now', 'start of month')");
+    query.bindValue(":username", globalUsername);
+
+    // 4. Execute the query and show a success or failure message.
+    if (query.exec()) {
+        AppUtils::showMessage(this, "Success", "Old income records have been deleted.");
+    } else {
+        qWarning() << "Failed to delete old income records:" << query.lastError().text();
+        AppUtils::showMessage(this, "Database Error", "Could not delete old records.");
+    }
+
+    // 5. Refresh the table view to show that the old records are gone.
+    refreshTable();
+}

--- a/incomeui.h
+++ b/incomeui.h
@@ -39,6 +39,7 @@ private slots:
     //void on_pushButton_clicked();
 
     void on_pushButton_Add_clicked();
+    void on_deleteOldRecordsButton_clicked();
 
 private:
     Ui::Incomeui *ui;

--- a/incomeui.ui
+++ b/incomeui.ui
@@ -19,7 +19,7 @@
   </property>
   <property name="styleSheet">
    <string notr="true">
-QDialog{border-image: url(:/image/Background04.png) 0 0 0 0 stretch stretch;}
+#Incomeui{border-image: url(:/image/Background04.png) 0 0 0 0 stretch stretch;}
 </string>
   </property>
   <widget class="QPushButton" name="pushButton_back">
@@ -174,7 +174,7 @@ font: 700 10pt &quot;Segoe UI&quot;;
       <x>40</x>
       <y>170</y>
       <width>471</width>
-      <height>31</height>
+      <height>41</height>
      </rect>
     </property>
     <layout class="QHBoxLayout" name="horizontalLayout_4">
@@ -283,6 +283,28 @@ color: white;</string>
    </property>
    <property name="text">
     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:36pt; font-weight:700; color:#841ebc;&quot;&gt;INCOME TRACKER&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+   </property>
+  </widget>
+  <widget class="QPushButton" name="deleteOldRecordsButton">
+   <property name="geometry">
+    <rect>
+     <x>1030</x>
+     <y>720</y>
+     <width>141</width>
+     <height>31</height>
+    </rect>
+   </property>
+   <property name="styleSheet">
+    <string notr="true">border: 3px solid #ff000d;
+background-color:#ff000d;
+border-radius: 15px;
+color: white;
+font: 700 10pt &quot;Segoe UI&quot;;
+
+</string>
+   </property>
+   <property name="text">
+    <string>Delete Old Records</string>
    </property>
   </widget>
  </widget>

--- a/shedulemaneger.ui
+++ b/shedulemaneger.ui
@@ -212,7 +212,7 @@ color: white;</string>
        <x>10</x>
        <y>130</y>
        <width>411</width>
-       <height>41</height>
+       <height>51</height>
       </rect>
      </property>
      <layout class="QHBoxLayout" name="horizontalLayout_2">
@@ -237,16 +237,13 @@ color: white;</string>
         </property>
         <property name="dateTime">
          <datetime>
-          <hour>0</hour>
-          <minute>0</minute>
+          <hour>18</hour>
+          <minute>30</minute>
           <second>0</second>
-          <year>2000</year>
-          <month>1</month>
-          <day>1</day>
+          <year>1999</year>
+          <month>12</month>
+          <day>31</day>
          </datetime>
-        </property>
-        <property name="timeSpec">
-         <enum>Qt::TimeSpec::LocalTime</enum>
         </property>
        </widget>
       </item>
@@ -293,9 +290,6 @@ color: white;</string>
         </property>
         <property name="currentSectionIndex">
          <number>0</number>
-        </property>
-        <property name="timeSpec">
-         <enum>Qt::TimeSpec::LocalTime</enum>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
Introduced a button and handler in both expense and income modules to allow users to delete all records from previous months after confirmation. Updated UI files to include the new button and adjusted some widget properties. Also refined stylesheet selectors for dialog backgrounds.